### PR TITLE
fix: 프론트엔드 lint 오류 정리

### DIFF
--- a/src/app/account/edit/page.tsx
+++ b/src/app/account/edit/page.tsx
@@ -50,6 +50,16 @@ function AccountEditContent() {
   const [districts, setDistricts] = useState<District[]>([]);
   const [isLoadingDistricts, setIsLoadingDistricts] = useState(false);
 
+  const handleProvinceChange = (provinceId: string) => {
+    setDistricts([]);
+    setIsLoadingDistricts(false);
+    setForm((prev) => ({
+      ...prev,
+      provinceId,
+      districtId: "",
+    }));
+  };
+
   const formatBirthDate = (raw: string) => {
     const digits = raw.replace(/\D/g, "").slice(0, 8);
     const y = digits.slice(0, 4);
@@ -108,8 +118,6 @@ function AccountEditContent() {
   // 시/도 선택 시 시/군/구 목록 로드
   useEffect(() => {
     if (!form.provinceId) {
-      setDistricts([]);
-      setForm((prev) => ({ ...prev, districtId: "" }));
       return;
     }
 
@@ -252,9 +260,7 @@ function AccountEditContent() {
                 <div>
                   <Select
                     value={form.provinceId}
-                    onChange={(v) =>
-                      setForm((prev) => ({ ...prev, provinceId: v }))
-                    }
+                    onChange={handleProvinceChange}
                     placeholder="시/도 선택"
                     options={[
                       { value: "", label: "시/도 선택" },

--- a/src/app/account/profile/page.tsx
+++ b/src/app/account/profile/page.tsx
@@ -43,6 +43,16 @@ export default function AccountProfilePage() {
   const [districts, setDistricts] = useState<District[]>([]);
   const [isLoadingDistricts, setIsLoadingDistricts] = useState(false);
 
+  const handleProvinceChange = (provinceId: string) => {
+    setDistricts([]);
+    setIsLoadingDistricts(false);
+    setForm((prev) => ({
+      ...prev,
+      provinceId,
+      districtId: "",
+    }));
+  };
+
   const formatBirthDate = (raw: string) => {
     const digits = raw.replace(/\D/g, "").slice(0, 8);
     const y = digits.slice(0, 4);
@@ -115,8 +125,6 @@ export default function AccountProfilePage() {
   // 시/도 선택 시 시/군/구 목록 로드
   useEffect(() => {
     if (!form.provinceId) {
-      setDistricts([]);
-      setForm((prev) => ({ ...prev, districtId: "" }));
       return;
     }
 
@@ -133,8 +141,6 @@ export default function AccountProfilePage() {
         if (!abortController.signal.aborted) {
           setDistricts(districtsList);
           setIsLoadingDistricts(false);
-          // 시/도 변경 시 districtId 초기화
-          setForm((prev) => ({ ...prev, districtId: "" }));
         }
       } catch (error) {
         // AbortError는 정상적인 취소이므로 무시
@@ -222,9 +228,7 @@ export default function AccountProfilePage() {
                 <div>
                   <Select
                     value={form.provinceId}
-                    onChange={(v) =>
-                      setForm((prev) => ({ ...prev, provinceId: v }))
-                    }
+                    onChange={handleProvinceChange}
                     placeholder="시/도 선택"
                     options={[
                       { value: "", label: "시/도 선택" },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
     { id: "finished-tournaments", title: "종료된 대회", type: "finished" },
   ];
 
-  const placeholderCards: any[] = []; // Start with empty state to show the improvement
+  const placeholderCards: string[] = []; // Start with empty state to show the improvement
 
   useEffect(() => {
     const el = tournamentsSectionRef.current;
@@ -120,7 +120,7 @@ export default function Home() {
               <div className="min-h-[200px]">
                 {placeholderCards.length > 0 ? (
                   <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                    {placeholderCards.map((card: any) => (
+                    {placeholderCards.map((card) => (
                       <div
                         key={card}
                         className="bg-background-card p-6 rounded-xl shadow-sm ring-1 ring-border"

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 type Theme = "light" | "dark";
 
@@ -16,43 +22,44 @@ const THEME_KEY = "rallyon-theme";
 const LEGACY_THEME_KEY = "drive-theme";
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>("light");
-  const [mounted, setMounted] = useState(false);
+  const isHydrated = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === "undefined") {
+      return "light";
+    }
 
-  // 초기 테마 로드 (localStorage 또는 시스템 설정)
-  useEffect(() => {
-    setMounted(true);
     const savedTheme = localStorage.getItem(THEME_KEY) as Theme | null;
     const legacyTheme = localStorage.getItem(LEGACY_THEME_KEY) as Theme | null;
     const initialTheme = savedTheme ?? legacyTheme;
 
     if (initialTheme) {
-      setThemeState(initialTheme);
-      localStorage.setItem(THEME_KEY, initialTheme);
       if (!savedTheme && legacyTheme) {
+        localStorage.setItem(THEME_KEY, initialTheme);
         localStorage.removeItem(LEGACY_THEME_KEY);
       }
-    } else {
-      // 시스템 다크 모드 감지
-      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      setThemeState(prefersDark ? "dark" : "light");
+      return initialTheme;
     }
-  }, []);
+
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    return prefersDark ? "dark" : "light";
+  });
 
   // 테마 변경 시 DOM 및 localStorage 업데이트
   useEffect(() => {
-    if (!mounted) return;
-
     const root = document.documentElement;
-    
+
     if (theme === "dark") {
       root.classList.add("dark");
     } else {
       root.classList.remove("dark");
     }
-    
+
     localStorage.setItem(THEME_KEY, theme);
-  }, [theme, mounted]);
+  }, [theme]);
 
   const toggleTheme = () => {
     setThemeState((prev) => (prev === "light" ? "dark" : "light"));
@@ -63,9 +70,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   };
 
   // 마운트 전에는 기본 라이트 테마로 렌더링 (hydration 불일치 방지)
-  if (!mounted) {
+  if (!isHydrated) {
     return (
-      <ThemeContext.Provider value={{ theme: "light", toggleTheme: () => {}, setTheme: () => {} }}>
+      <ThemeContext.Provider
+        value={{ theme: "light", toggleTheme: () => {}, setTheme: () => {} }}
+      >
         {children}
       </ThemeContext.Provider>
     );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -447,7 +447,7 @@ export async function getCurrentUser(
   accessToken?: string
 ): Promise<User | null> {
   // 액세스 토큰이 제공되지 않으면 저장된 토큰 사용
-  let token = accessToken || getAccessToken();
+  const token = accessToken || getAccessToken();
 
   // 토큰이 없거나 빈 문자열이면 API 호출하지 않음 (비로그인 상태)
   if (!token || !token.trim()) {

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -96,7 +96,7 @@ interface ApiResponse<T> {
 
 // 인증 헤더 생성
 async function getAuthHeaders(): Promise<HeadersInit> {
-  let token = getAccessToken();
+  const token = getAccessToken();
 
   const headers: HeadersInit = {
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- remove the current lint errors without expanding the scope into unrelated warnings
- move district reset logic out of effects to satisfy the React lint rule
- replace explicit any and prefer-const violations in shared frontend utilities

## Validation
- npm run lint (passes with warnings only)

Closes #10