### PR TITLE
fix: forwarded host 기반 auth 진입 판별을 보완한다

### DIFF
--- a/src/app/auth-page-utils.ts
+++ b/src/app/auth-page-utils.ts
@@ -17,3 +17,9 @@ export function buildAuthPageUrl(returnTo: string, screen: AuthScreen) {
   url.searchParams.set("returnTo", returnTo);
   return url.toString();
 }
+
+export function resolveRequestHost(headerStore: Headers) {
+  const forwardedHost = headerStore.get("x-forwarded-host");
+  const host = forwardedHost || headerStore.get("host") || "";
+  return host.split(",")[0].trim().split(":")[0];
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import {
   buildAuthPageUrl,
   getAuthUrl,
   normalizeReturnTo,
+  resolveRequestHost,
 } from "../auth-page-utils";
 import LoginPageClient from "./login-page-client";
 
@@ -19,7 +20,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
   const headerStore = await headers();
-  const host = (headerStore.get("host") || "").split(":")[0];
+  const host = resolveRequestHost(headerStore);
   const authHost = new URL(getAuthUrl()).host;
 
   if (host !== authHost) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,6 +4,7 @@ import {
   buildAuthPageUrl,
   getAuthUrl,
   normalizeReturnTo,
+  resolveRequestHost,
 } from "../auth-page-utils";
 import SignupPageClient from "./signup-page-client";
 
@@ -19,7 +20,7 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
   const headerStore = await headers();
-  const host = (headerStore.get("host") || "").split(":")[0];
+  const host = resolveRequestHost(headerStore);
   const authHost = new URL(getAuthUrl()).host;
 
   if (host !== authHost) {


### PR DESCRIPTION
## 요약
- auth host 판별 시 `x-forwarded-host` 를 우선 사용하도록 보완합니다.
- reverse proxy가 `Host` 를 프론트 canonical host로 넘겨도 `/login`, `/signup` 흐름이 유지되도록 합니다.

## 검증
- `npm run lint`
- `npx next build --webpack`

Refs #31
