### PR TITLE
fix: auth 공개 호스트 커스텀 헤더를 적용한다

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL || "https://auth.rallyon.test";
+
+function normalizeHeaderHost(value?: string | null) {
+  return (value || "").split(",")[0].trim().split(":")[0];
+}
+
+export function middleware(request: NextRequest) {
+  const authHost = new URL(AUTH_URL).host;
+  const publicHost = normalizeHeaderHost(
+    request.headers.get("x-rallyon-public-host"),
+  );
+
+  if (publicHost === authHost) {
+    return NextResponse.next();
+  }
+
+  const redirectUrl = new URL(
+    `${request.nextUrl.pathname}${request.nextUrl.search}`,
+    AUTH_URL,
+  );
+
+  return NextResponse.redirect(redirectUrl);
+}
+
+export const config = {
+  matcher: ["/login", "/signup"],
+};

--- a/src/app/auth-page-utils.ts
+++ b/src/app/auth-page-utils.ts
@@ -12,30 +12,8 @@ export function getAuthUrl() {
   return process.env.NEXT_PUBLIC_AUTH_URL || "https://auth.rallyon.test";
 }
 
-function normalizeHeaderHost(value?: string | null) {
-  return (value || "").split(",")[0].trim().split(":")[0];
-}
-
 export function buildAuthPageUrl(returnTo: string, screen: AuthScreen) {
   const url = new URL(`/${screen}`, getAuthUrl());
   url.searchParams.set("returnTo", returnTo);
   return url.toString();
-}
-
-export function resolveRequestHost(headerStore: Headers) {
-  const publicHost = normalizeHeaderHost(
-    headerStore.get("x-rallyon-public-host"),
-  );
-  if (publicHost) {
-    return publicHost;
-  }
-
-  const forwardedHost = normalizeHeaderHost(
-    headerStore.get("x-forwarded-host"),
-  );
-  if (forwardedHost) {
-    return forwardedHost;
-  }
-
-  return normalizeHeaderHost(headerStore.get("host"));
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,4 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import {
-  buildAuthPageUrl,
-  getAuthUrl,
-  normalizeReturnTo,
-  resolveRequestHost,
-} from "../auth-page-utils";
+import { normalizeReturnTo } from "../auth-page-utils";
 import LoginPageClient from "./login-page-client";
 
 interface LoginPageProps {
@@ -19,13 +12,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = searchParams ? await searchParams : undefined;
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
-  const headerStore = await headers();
-  const host = resolveRequestHost(headerStore);
-  const authHost = new URL(getAuthUrl()).host;
-
-  if (host !== authHost) {
-    redirect(buildAuthPageUrl(returnTo, "login"));
-  }
 
   return <LoginPageClient returnTo={returnTo} errorCode={errorCode} />;
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,11 +1,4 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import {
-  buildAuthPageUrl,
-  getAuthUrl,
-  normalizeReturnTo,
-  resolveRequestHost,
-} from "../auth-page-utils";
+import { normalizeReturnTo } from "../auth-page-utils";
 import SignupPageClient from "./signup-page-client";
 
 interface SignupPageProps {
@@ -19,13 +12,6 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   const params = searchParams ? await searchParams : undefined;
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
-  const headerStore = await headers();
-  const host = resolveRequestHost(headerStore);
-  const authHost = new URL(getAuthUrl()).host;
-
-  if (host !== authHost) {
-    redirect(buildAuthPageUrl(returnTo, "signup"));
-  }
 
   return <SignupPageClient returnTo={returnTo} errorCode={errorCode} />;
 }


### PR DESCRIPTION
## Summary
- auth host 판별 기준을 X-RallyOn-Public-Host 우선으로 정리합니다
- x-forwarded-host는 차선 fallback으로만 사용합니다
- auth origin 로그인 루프를 끊기 위한 hotfix입니다

## Test
- npm run lint
- npx next build --webpack

Refs #31