### PR TITLE
chore: auth hotfix를 dev에 동기화한다

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const AUTH_URL =
+  process.env.NEXT_PUBLIC_AUTH_URL || "https://auth.rallyon.test";
+
+function normalizeHeaderHost(value?: string | null) {
+  return (value || "").split(",")[0].trim().split(":")[0];
+}
+
+export function middleware(request: NextRequest) {
+  const authHost = new URL(AUTH_URL).host;
+  const publicHost = normalizeHeaderHost(
+    request.headers.get("x-rallyon-public-host"),
+  );
+
+  if (publicHost === authHost) {
+    return NextResponse.next();
+  }
+
+  const redirectUrl = new URL(
+    `${request.nextUrl.pathname}${request.nextUrl.search}`,
+    AUTH_URL,
+  );
+
+  return NextResponse.redirect(redirectUrl);
+}
+
+export const config = {
+  matcher: ["/login", "/signup"],
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,4 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import {
-  buildAuthPageUrl,
-  getAuthUrl,
-  normalizeReturnTo,
-} from "../auth-page-utils";
+import { normalizeReturnTo } from "../auth-page-utils";
 import LoginPageClient from "./login-page-client";
 
 interface LoginPageProps {
@@ -18,13 +12,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = searchParams ? await searchParams : undefined;
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
-  const headerStore = await headers();
-  const host = (headerStore.get("host") || "").split(":")[0];
-  const authHost = new URL(getAuthUrl()).host;
-
-  if (host !== authHost) {
-    redirect(buildAuthPageUrl(returnTo, "login"));
-  }
 
   return <LoginPageClient returnTo={returnTo} errorCode={errorCode} />;
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,10 +1,4 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import {
-  buildAuthPageUrl,
-  getAuthUrl,
-  normalizeReturnTo,
-} from "../auth-page-utils";
+import { normalizeReturnTo } from "../auth-page-utils";
 import SignupPageClient from "./signup-page-client";
 
 interface SignupPageProps {
@@ -18,13 +12,6 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   const params = searchParams ? await searchParams : undefined;
   const returnTo = normalizeReturnTo(params?.returnTo);
   const errorCode = params?.error;
-  const headerStore = await headers();
-  const host = (headerStore.get("host") || "").split(":")[0];
-  const authHost = new URL(getAuthUrl()).host;
-
-  if (host !== authHost) {
-    redirect(buildAuthPageUrl(returnTo, "signup"));
-  }
 
   return <SignupPageClient returnTo={returnTo} errorCode={errorCode} />;
 }


### PR DESCRIPTION
## Summary
- sync the auth public host hotfix into `dev` without a full `main -> dev` merge
- add middleware-based redirects for `/login` and `/signup`
- remove page-level host redirect logic so `dev` matches the current production auth flow

## Test
- npm run lint
- npx next build --webpack