### PR TITLE
chore: frontend GitHub Actions major version을 갱신한다

### DIFF
--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate workflow policy
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           BRANCH_REGEX: "^(feat|fix|refactor|docs|chore|test|style)/[0-9]+-[a-z0-9-]+$"
           TITLE_REGEX: "^(feat|fix|refactor|docs|chore|test|style): .+$"


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions major versions in the frontend policy workflow
- keep the current policy behavior intact while removing Node 20 deprecation warnings

## Changes
- github-script v8

## Test
- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/policy.yml\"); puts \"frontend workflow ok\""