### PR TITLE
feat: 자유게임 생성 요청에 scheduledAt 계약을 연동한다

### DIFF
--- a/src/app/court-manager/create/page.tsx
+++ b/src/app/court-manager/create/page.tsx
@@ -499,6 +499,7 @@ export default function CreateFreeGamePage() {
           roundCount: rounds.length,
           gradeType: "REGIONAL",
           matchRecordMode: "RESULT",
+          scheduledAt: date,
           location: trimmedLocation,
           participants: participants.map((participant) => ({
             clientId: participant.clientId,

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -54,6 +54,8 @@ export interface Game {
   createdBy: string;
   matchRecordMode: MatchRecordMode;
   gradeType: GradeType;
+  scheduledAt?: string | null;
+  location?: string | null;
 }
 
 export interface PublicGameSummary {
@@ -90,6 +92,7 @@ export interface CreateGameRequest {
   roundCount: number;
   gradeType: GradeType;
   matchRecordMode?: MatchRecordMode;
+  scheduledAt: string;
   location?: string;
   managerIds?: string[];
   participants: CreateGameParticipant[];
@@ -100,6 +103,8 @@ export interface UpdateGameRequest {
   title?: string;
   matchRecordMode?: MatchRecordMode;
   gradeType?: GradeType;
+  scheduledAt?: string | null;
+  location?: string | null;
   managerIds?: string[];
 }
 
@@ -124,8 +129,10 @@ interface FreeGameDetailResponse {
   gradeType: GradeType;
   courtCount: number;
   roundCount: number;
-  organizerId: string;
+  organizerAccountId: string;
   shareCode: string;
+  scheduledAt?: string | null;
+  location?: string | null;
 }
 
 interface FreeGameParticipantResponse {
@@ -224,9 +231,11 @@ function mapGame(
     roundCount: detail.roundCount,
     status: detail.gameStatus,
     shareCode: detail.shareCode,
-    createdBy: detail.organizerId,
+    createdBy: detail.organizerAccountId,
     matchRecordMode: detail.matchRecordMode,
     gradeType: detail.gradeType,
+    scheduledAt: detail.scheduledAt ?? null,
+    location: detail.location ?? null,
     participants: participants.participants.map(mapParticipant),
     rounds: mapRounds(rounds.rounds),
   };


### PR DESCRIPTION
## 요약
- 자유게임 생성 요청 타입에 `scheduledAt` 필드를 추가
- 코트매니저 생성 화면이 선택한 날짜/시간을 실제 payload에 포함하도록 연결
- backend detail 계약에 맞춰 organizerAccountId/scheduledAt/location 필드를 반영

## 검증
- npm run lint

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

- 게임을 생성할 때 게임이 예약될 날짜와 시간을 지정할 수 있습니다.
- 게임의 진행 위치 정보를 추가하여 체계적으로 관리할 수 있습니다.
- 게임 상세 정보 페이지에서 예약된 날짜와 위치 정보를 언제든 확인하고 수정할 수 있습니다.
- 기존 게임의 예약 날짜와 위치 정보를 업데이트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->